### PR TITLE
Expose predict_aj_estimates

### DIFF
--- a/src/polarstate/__init__.py
+++ b/src/polarstate/__init__.py
@@ -1,6 +1,37 @@
-from .aj import aalen_johansen
+"""Expose the main public API for :mod:`polarstate`."""
 
-__all__ = ["aalen_johansen"]
+from .aj import (
+    aalen_johansen,
+    add_at_risk_column,
+    add_cause_specific_hazards_columns,
+    add_events_at_times_column,
+    add_overall_survival_column,
+    add_previous_overal_survival_column,
+    add_state_occupancy_probabilities_at_times_columns,
+    add_transition_probabilities_at_times_columns,
+    create_sorted_times_and_reals_data,
+    group_reals_by_times,
+    prepare_event_table,
+)
+
+# ``predict_aj_estimates`` is provided as a convenience alias so users can simply
+# ``from polarstate import predict_aj_estimates``.
+predict_aj_estimates = aalen_johansen
+
+__all__ = [
+    "predict_aj_estimates",
+    "aalen_johansen",
+    "create_sorted_times_and_reals_data",
+    "group_reals_by_times",
+    "add_events_at_times_column",
+    "add_at_risk_column",
+    "add_cause_specific_hazards_columns",
+    "add_overall_survival_column",
+    "add_previous_overal_survival_column",
+    "add_transition_probabilities_at_times_columns",
+    "add_state_occupancy_probabilities_at_times_columns",
+    "prepare_event_table",
+]
 
 
 def main() -> None:

--- a/tests/test_polarstate.py
+++ b/tests/test_polarstate.py
@@ -59,6 +59,19 @@ def test_create_sorted_times_and_reals_data() -> None:
     assert_frame_equal(result, expected_output)
 
 
+def test_predict_aj_estimates_alias() -> None:
+    """Ensure users can import ``predict_aj_estimates`` from ``polarstate``."""
+    times = pl.Series([1, 2, 3])
+    reals = pl.Series([1, 0, 0])
+
+    from polarstate import predict_aj_estimates
+
+    result_root = predict_aj_estimates(times, reals)
+    result_direct = aalen_johansen(times, reals)
+
+    assert_frame_equal(result_root, result_direct)
+
+
 def test_add_events_at_times_column() -> None:
     times_and_counts = pl.DataFrame(
         {


### PR DESCRIPTION
## Summary
- collect public functions in `polarstate/__init__.py`
- expose `predict_aj_estimates` at package root as an alias of `aalen_johansen`
- test that the alias can be imported from the root package

## Testing
- `ruff check .`
- `ruff format .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_684ad2daf3b8832ab41b4630109023de