### PR TITLE
Expose predict_aj_estimates from package root

### DIFF
--- a/src/polarstate/__init__.py
+++ b/src/polarstate/__init__.py
@@ -1,6 +1,9 @@
-from .aj import aalen_johansen
+"""Public API for the :mod:`polarstate` package."""
 
-__all__ = ["aalen_johansen"]
+from .aj import aalen_johansen, prepare_event_table
+from .predict import predict_aj_estimates
+
+__all__ = ["aalen_johansen", "prepare_event_table", "predict_aj_estimates"]
 
 
 def main() -> None:

--- a/src/polarstate/predict.py
+++ b/src/polarstate/predict.py
@@ -1,0 +1,21 @@
+import polars as pl
+from .aj import prepare_event_table
+
+
+def predict_aj_estimates(times: pl.Series, reals: pl.Series) -> pl.DataFrame:
+    """Predict state occupancy probabilities using the Aalen-Johansen estimator.
+
+    Parameters
+    ----------
+    times : pl.Series
+        Event or censoring times for each observation.
+    reals : pl.Series
+        Event type for each observation.
+
+    Returns
+    -------
+    pl.DataFrame
+        The event table with intermediate calculations.
+    """
+    times_and_reals = pl.DataFrame({"times": times, "reals": reals})
+    return prepare_event_table(times_and_reals)


### PR DESCRIPTION
## Summary
- expose `predict_aj_estimates` from the package root
- implement `predict_aj_estimates` helper

## Testing
- `ruff check src/polarstate/predict.py src/polarstate/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_6850378ecdf4832a9b9d23e2e5674da7