### PR TITLE
Migrate documentation to Great Docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Documentation
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Install dependencies
+        run: |
+          pip install great-docs
+          pip install -e .
+
+      - name: Build documentation
+        run: great-docs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: great-docs/_site
+          include-hidden-files: true
+
+  publish-docs:
+    needs: build-docs
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,46 +5,64 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-docs:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
+        if: github.event.action != 'closed'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Set up Quarto
+        if: github.event.action != 'closed'
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Install dependencies
+        if: github.event.action != 'closed'
         run: |
           pip install great-docs
           pip install -e .
 
       - name: Build documentation
+        if: github.event.action != 'closed'
         run: great-docs build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload rendered site
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
         with:
+          name: great-docs-site
           path: great-docs/_site
           include-hidden-files: true
 
-  publish-docs:
-    needs: build-docs
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy production site
+        if: github.event_name == 'push'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: great-docs/_site
+          branch: gh-pages
+          clean-exclude: pr-preview
+          force: false
+
+      - name: Deploy pull request preview
+        if: github.event_name == 'pull_request'
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: great-docs/_site
+          preview-branch: gh-pages
+          wait-for-pages-deployment: true
+          qr-code: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
-on:
-  workflow_dispatch:
-  push:
-    branches: master
+on: workflow_dispatch
 
-name: Quarto Publish
+name: Legacy Quarto Publish (manual)
 
 jobs:
   build-deploy:
@@ -25,7 +22,7 @@ jobs:
       - name: Build package using uv
         run: uv build
 
-      - name: 🐍 Set up Python
+      - name: Set up Python
         run: uv python install
 
       - name: Install Jupyter

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 wheels/
 *.egg-info
 
+# Documentation build output
+great-docs/
+
 # Virtual environments
-**/*.html
-docs/_site/search.json
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# polarstate
+
+Fast, Polars-native Aalen-Johansen estimates for competing-risks data.
+
+`polarstate` turns event times and outcomes into an event table, then predicts
+state-occupancy probabilities at the time horizons you care about. The public
+API is deliberately small: one function prepares the estimates and one function
+queries them.
+
+## Install
+
+```bash
+pip install polarstate
+```
+
+## Quick start
+
+```python
+import polars as pl
+from polarstate import prepare_event_table, predict_aj_estimates
+
+observations = pl.DataFrame(
+    {
+        "times": [24.1, 9.7, 49.9, 18.6, 34.8, 14.2, 39.2, 46.0, 31.5, 4.3],
+        "reals": [1, 1, 1, 1, 0, 2, 1, 2, 0, 1],
+    }
+)
+
+event_table = prepare_event_table(observations)
+estimates = predict_aj_estimates(
+    event_table,
+    pl.Series([10.0, 20.0, 30.0, 40.0, 50.0]),
+)
+
+print(estimates)
+```
+
+Outcomes use `0` for censoring, `1` for the primary event, and `2` for the
+competing event. See the [documentation](https://uriahf.github.io/polarstate/)
+for a complete walkthrough and API reference.
+
+## Why polarstate?
+
+- Polars-native inputs and outputs
+- A compact, explicit event table you can inspect
+- Predictions at arbitrary time horizons
+- Support for both single-event and competing-risks data

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # polarstate
 
-Fast, Polars-native Aalen-Johansen estimates for competing-risks data.
+Fast, Polars-native Aalen-Johansen estimates for time-to-event data.
 
 `polarstate` turns event times and outcomes into an event table, then predicts
-state-occupancy probabilities at the time horizons you care about. The public
-API is deliberately small: one function prepares the estimates and one function
-queries them.
+state-occupancy probabilities at the time horizons you care about. It supports
+ordinary single-event analyses and binary event/censoring data, with optional
+competing events. The public API is deliberately small: one function prepares
+the estimates and one function queries them.
 
 ## Install
 
@@ -35,13 +36,14 @@ estimates = predict_aj_estimates(
 print(estimates)
 ```
 
-Outcomes use `0` for censoring, `1` for the primary event, and `2` for the
-competing event. See the [documentation](https://uriahf.github.io/polarstate/)
-for a complete walkthrough and API reference.
+Outcomes use `0` for censoring and `1` for the event of interest. Use `2`
+only when the data include a competing event. See the
+[documentation](https://uriahf.github.io/polarstate/) for a complete
+walkthrough and API reference.
 
 ## Why polarstate?
 
 - Polars-native inputs and outputs
 - A compact, explicit event table you can inspect
 - Predictions at arbitrary time horizons
-- Support for both single-event and competing-risks data
+- Support for single-event, binary event/censoring, and competing-risks data

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -26,7 +26,7 @@ logo:
 logo_show_title: true
 hero:
   name: "Polars State"
-  tagline: "Fast Aalen-Johansen estimates, built for Polars."
+  tagline: "Fast time-to-event estimates, built for Polars."
   logo_height: 180px
   badges:
     - alt: PyPI version
@@ -56,11 +56,11 @@ changelog:
 reference:
   title: "API Reference"
   desc: >-
-    The complete public API for preparing Aalen-Johansen event tables and
-    predicting state-occupancy probabilities.
+    The complete public API for preparing time-to-event tables and predicting
+    state-occupancy probabilities, with or without competing events.
   sections:
     - title: "Estimation"
-      desc: "Build an inspectable event table from competing-risks observations."
+      desc: "Build an inspectable event table from time-to-event observations."
       contents:
         - prepare_event_table
     - title: "Prediction"

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -32,8 +32,8 @@ hero:
     - alt: PyPI version
       img: https://img.shields.io/pypi/v/polarstate
       url: https://pypi.org/project/polarstate/
-    - alt: Python versions
-      img: https://img.shields.io/pypi/pyversions/polarstate
+    - alt: Requires Python 3.9 or newer
+      img: https://img.shields.io/badge/python-%E2%89%A53.9-3776AB?logo=python&logoColor=white
       url: https://pypi.org/project/polarstate/
 
 nav_icons:

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -1,0 +1,69 @@
+display_name: "Polars State"
+package: polarstate
+parser: numpy
+user_guide: user_guide
+homepage: index
+site_url: https://uriahf.github.io/polarstate/
+
+github_style: widget
+dark_mode_toggle: true
+back_to_top: true
+keyboard_nav: true
+markdown_pages: true
+
+navbar_style: sky
+content_style:
+  preset: mint
+  pages: all
+accent_color:
+  light: "#1f5f82"
+  dark: "#73c7e8"
+
+logo:
+  light: docs/logo.png
+  dark: docs/logo.png
+  alt: Polars State
+logo_show_title: true
+hero:
+  name: "Polars State"
+  tagline: "Fast Aalen-Johansen estimates, built for Polars."
+  logo_height: 180px
+  badges:
+    - alt: PyPI version
+      img: https://img.shields.io/pypi/v/polarstate
+      url: https://pypi.org/project/polarstate/
+    - alt: Python versions
+      img: https://img.shields.io/pypi/pyversions/polarstate
+      url: https://pypi.org/project/polarstate/
+
+nav_icons:
+  navbar:
+    User Guide: book-open
+    Reference: code-2
+  sidebar:
+    Getting Started: rocket
+    Concepts: orbit
+
+source:
+  enabled: true
+  branch: master
+  path: src/polarstate
+  placement: usage
+
+changelog:
+  enabled: false
+
+reference:
+  title: "API Reference"
+  desc: >-
+    The complete public API for preparing Aalen-Johansen event tables and
+    predicting state-occupancy probabilities.
+  sections:
+    - title: "Estimation"
+      desc: "Build an inspectable event table from competing-risks observations."
+      contents:
+        - prepare_event_table
+    - title: "Prediction"
+      desc: "Evaluate state-occupancy probabilities at fixed time horizons."
+      contents:
+        - predict_aj_estimates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Uriah Finkel", email = "Ufinkel@gmail.com" }
 ]
-keywords = ["survival-analysis", "competing-risks", "polars", "aalen-johansen"]
+keywords = ["time-to-event", "survival-analysis", "competing-risks", "polars", "aalen-johansen"]
 requires-python = ">=3.9"
 dependencies = [
     "polars>=1.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,22 @@
 [project]
 name = "polarstate"
 version = "0.1.8"
-description = "Add your description here"
+description = "Fast Aalen-Johansen state-occupancy estimates for Polars DataFrames"
 readme = "README.md"
 authors = [
     { name = "Uriah Finkel", email = "Ufinkel@gmail.com" }
 ]
+keywords = ["survival-analysis", "competing-risks", "polars", "aalen-johansen"]
 requires-python = ">=3.9"
 dependencies = [
     "polars>=1.30.0",
 ]
+
+[project.urls]
+Homepage = "https://uriahf.github.io/polarstate/"
+Documentation = "https://uriahf.github.io/polarstate/"
+Repository = "https://github.com/uriahf/polarstate"
+Issues = "https://github.com/uriahf/polarstate/issues"
 
 [project.scripts]
 polarstate = "polarstate:main"
@@ -32,8 +39,6 @@ dev = [
     "pre-commit>=4.2.0",
     "pyarrow>=20.0.0",
     "pytest>=8.3.5",
-    "quarto>=0.1.0",
-    "quartodoc>=0.10.0",
     "ruff>=0.11.11",
     "ty>=0.0.1a14",
     "uv>=0.7.13",
@@ -43,4 +48,3 @@ dev = [
 testpaths = ["tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
-

--- a/user_guide/01-getting-started.qmd
+++ b/user_guide/01-getting-started.qmd
@@ -1,0 +1,69 @@
+---
+title: "Getting Started"
+description: "Estimate competing-risks probabilities with Polars in a few lines."
+guide-section: "Getting Started"
+---
+
+`polarstate` implements a compact Aalen-Johansen workflow with Polars
+DataFrames. It uses three outcome codes:
+
+| Code | Meaning |
+|---:|---|
+| `0` | Censored |
+| `1` | Primary event |
+| `2` | Competing event |
+
+## Install
+
+```bash
+pip install polarstate
+```
+
+## Prepare an event table
+
+Start with one row per observation. The `times` column contains the observed
+time and `reals` contains the outcome code.
+
+```python
+import polars as pl
+from polarstate import prepare_event_table
+
+observations = pl.DataFrame(
+    {
+        "times": [24.1, 9.7, 49.9, 18.6, 34.8, 14.2, 39.2, 46.0, 31.5, 4.3],
+        "reals": [1, 1, 1, 1, 0, 2, 1, 2, 0, 1],
+    }
+)
+
+event_table = prepare_event_table(observations)
+```
+
+The returned table exposes the risk set, cause-specific hazards, overall
+survival, and cumulative state-occupancy probabilities. Keeping these
+intermediate quantities visible makes the estimate easy to inspect and audit.
+
+## Predict at fixed horizons
+
+```python
+from polarstate import predict_aj_estimates
+
+estimates = predict_aj_estimates(
+    event_table,
+    pl.Series([10.0, 20.0, 30.0, 40.0, 50.0]),
+)
+```
+
+The result contains the requested time and one probability for each state.
+Each row sums to one (up to floating-point precision).
+
+::: {.callout-tip}
+## Need the observed event times too?
+
+Pass `full_event_table=True` to the prediction function to include estimates
+at every observed event time alongside your fixed horizons.
+:::
+
+## Where to go next
+
+- Read [How the estimator works](02-how-it-works.qmd) for the statistical flow.
+- Open the API Reference for signatures, parameter details, and source links.

--- a/user_guide/01-getting-started.qmd
+++ b/user_guide/01-getting-started.qmd
@@ -1,17 +1,21 @@
 ---
 title: "Getting Started"
-description: "Estimate competing-risks probabilities with Polars in a few lines."
+description: "Estimate time-to-event probabilities with Polars in a few lines."
 guide-section: "Getting Started"
 ---
 
 `polarstate` implements a compact Aalen-Johansen workflow with Polars
-DataFrames. It uses three outcome codes:
+DataFrames. It works for ordinary single-event analyses and binary
+event/censoring data, while also supporting an optional competing event.
 
 | Code | Meaning |
 |---:|---|
 | `0` | Censored |
-| `1` | Primary event |
-| `2` | Competing event |
+| `1` | Event of interest |
+| `2` | Competing event (optional) |
+
+For a simple time-to-event or binary event/censoring analysis, use only `0`
+and `1`.
 
 ## Install
 

--- a/user_guide/02-how-it-works.qmd
+++ b/user_guide/02-how-it-works.qmd
@@ -1,0 +1,31 @@
+---
+title: "How the Estimator Works"
+description: "The calculation behind polarstate's event table."
+guide-section: "Concepts"
+---
+
+The Aalen-Johansen estimator extends Kaplan-Meier reasoning to multiple
+absorbing outcomes. `polarstate` makes each stage available as a column in the
+event table.
+
+## Calculation flow
+
+1. Observations are grouped by time and counted by outcome.
+2. The risk set is computed at each observed time.
+3. Cause-specific hazards are calculated for event types 1 and 2.
+4. Conditional survival is accumulated into overall survival.
+5. The previous survival probability weights each cause-specific hazard.
+6. Weighted transitions are cumulatively summed into state-occupancy
+   probabilities.
+
+For a requested time horizon, the prediction function performs a backward
+as-of join: it returns the latest estimate available at or before that horizon.
+Horizons before the first observed event receive probability 1 for state 0 and
+0 for the absorbing states.
+
+::: {.callout-note}
+## Input contract
+
+The current estimator expects outcomes encoded as `0`, `1`, or `2`. Validate
+and recode upstream data before preparing the event table.
+:::

--- a/user_guide/02-how-it-works.qmd
+++ b/user_guide/02-how-it-works.qmd
@@ -4,15 +4,18 @@ description: "The calculation behind polarstate's event table."
 guide-section: "Concepts"
 ---
 
-The Aalen-Johansen estimator extends Kaplan-Meier reasoning to multiple
-absorbing outcomes. `polarstate` makes each stage available as a column in the
-event table.
+The Aalen-Johansen estimator generalizes Kaplan-Meier reasoning to one or more
+absorbing outcomes. With only outcome codes `0` and `1`, `polarstate`
+handles an ordinary single-event or binary event/censoring analysis. Adding
+outcome code `2` introduces a competing event. Each calculation stage remains
+available as a column in the event table.
 
 ## Calculation flow
 
 1. Observations are grouped by time and counted by outcome.
 2. The risk set is computed at each observed time.
-3. Cause-specific hazards are calculated for event types 1 and 2.
+3. Cause-specific hazards are calculated for the event of interest and the
+   optional competing event.
 4. Conditional survival is accumulated into overall survival.
 5. The previous survival probability weights each cause-specific hazard.
 6. Weighted transitions are cumulatively summed into state-occupancy
@@ -26,6 +29,7 @@ Horizons before the first observed event receive probability 1 for state 0 and
 ::: {.callout-note}
 ## Input contract
 
-The current estimator expects outcomes encoded as `0`, `1`, or `2`. Validate
-and recode upstream data before preparing the event table.
+The estimator expects outcomes encoded as `0` or `1`, with `2` used only
+when a competing event is present. Validate and recode upstream data before
+preparing the event table.
 :::


### PR DESCRIPTION
## What changed

- replaces the quartodoc configuration with Great Docs
- adds a branded landing page and two-page user guide
- broadens the documentation language to cover simple time-to-event, binary event/censoring, and competing-risk data
- organizes the public API into estimation and prediction sections
- adds dark mode, responsive navigation, source links, SEO output, and GitHub Pages deployment
- adds automatic per-PR documentation previews under `/pr-preview/pr-<number>/`
- keeps production deployment on the `gh-pages` branch while preserving active previews
- disables automatic execution of the legacy Quarto publishing workflow
- removes quartodoc and quarto from the development dependency list

## Why

The existing public site is generated by the legacy quartodoc workflow. This migration keeps the Polars State visual identity while moving generation and deployment to Great Docs.

## User impact

After this PR is merged, https://uriahf.github.io/polarstate/ will serve the Great Docs site. Documentation pull requests receive an automatically updated preview URL without replacing production.

## Validation

- Great Docs build completed successfully
- hosted preview: https://uriahf.github.io/polarstate/pr-preview/pr-68/
- documentation workflow passed
- package test workflow passed
