### PR TITLE
Use canonical transition probability column names

### DIFF
--- a/src/polarstate/aj.py
+++ b/src/polarstate/aj.py
@@ -164,16 +164,16 @@ def add_transition_probabilities_at_times_columns(
     -------
     pl.DataFrame
         The input DataFrame with additional columns:
-        - 'trainsition_probabilities_to_1_at_times': transition probability to event type 1 at each time point,
-        - 'trainsition_probabilities_to_2_at_times': transition probability to event type 2 at each time point.
+        - 'transition_probabilities_to_1_at_times': transition probability to event type 1 at each time point,
+        - 'transition_probabilities_to_2_at_times': transition probability to event type 2 at each time point.
     """
     return events_data.with_columns(
         [
             (pl.col("csh_1") * pl.col("previous_overall_survival")).alias(
-                "trainsition_probabilities_to_1_at_times"
+                "transition_probabilities_to_1_at_times"
             ),
             (pl.col("csh_2") * pl.col("previous_overall_survival")).alias(
-                "trainsition_probabilities_to_2_at_times"
+                "transition_probabilities_to_2_at_times"
             ),
         ]
     )
@@ -183,11 +183,11 @@ def add_state_occupancy_probabilities_at_times_columns(
     events_data: pl.DataFrame,
 ) -> pl.DataFrame:
     """
-    Add columns for state occupancy probabilities at each time point based on trainsition_probabilities_to_1_at_times and trainsition_probabilities_to_2_at_times columns.
+    Add columns for state occupancy probabilities at each time point based on transition probability columns.
     Parameters
     ----------
     events_data : pl.DataFrame
-        A Polars DataFrame with columns 'trainsition_probabilities_to_1_at_times' and 'trainsition_probabilities_to_2_at_times'.
+        A Polars DataFrame with columns 'transition_probabilities_to_1_at_times' and 'transition_probabilities_to_2_at_times'.
     Returns
     -------
     pl.DataFrame
@@ -197,10 +197,10 @@ def add_state_occupancy_probabilities_at_times_columns(
     """
     return events_data.with_columns(
         [
-            pl.col("trainsition_probabilities_to_1_at_times")
+            pl.col("transition_probabilities_to_1_at_times")
             .cum_sum()
             .alias("state_occupancy_probability_1_at_times"),
-            pl.col("trainsition_probabilities_to_2_at_times")
+            pl.col("transition_probabilities_to_2_at_times")
             .cum_sum()
             .alias("state_occupancy_probability_2_at_times"),
         ]
@@ -240,16 +240,16 @@ def _validate_observations(times_and_reals: pl.DataFrame) -> None:
         raise ValueError("The 'reals' column may contain only 0, 1, and 2.")
 
 
-def _add_correctly_spelled_transition_aliases(
+def _add_legacy_transition_aliases(
     events_data: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Add corrected names while retaining the historical misspellings."""
+    """Retain the historical misspellings as backward-compatible aliases."""
     return events_data.with_columns(
-        pl.col("trainsition_probabilities_to_1_at_times").alias(
-            "transition_probabilities_to_1_at_times"
+        pl.col("transition_probabilities_to_1_at_times").alias(
+            "trainsition_probabilities_to_1_at_times"
         ),
-        pl.col("trainsition_probabilities_to_2_at_times").alias(
-            "transition_probabilities_to_2_at_times"
+        pl.col("transition_probabilities_to_2_at_times").alias(
+            "trainsition_probabilities_to_2_at_times"
         ),
     )
 
@@ -316,5 +316,6 @@ def prepare_event_table(times_and_reals: pl.DataFrame) -> pl.DataFrame:
         .pipe(add_previous_overal_survival_column)
         .pipe(add_transition_probabilities_at_times_columns)
         .pipe(add_state_occupancy_probabilities_at_times_columns)
-        .pipe(_add_correctly_spelled_transition_aliases)
+        .pipe(_add_legacy_transition_aliases)
     )
+

--- a/tests/test_polarstate.py
+++ b/tests/test_polarstate.py
@@ -244,12 +244,12 @@ def test_add_transition_probabilities_at_times_columns() -> None:
                 (6 / 7) * (3 / 5) * 0.0,
             ],
             "previous_overall_survival": [1.0, (6 / 7), (6 / 7) * (3 / 5)],
-            "trainsition_probabilities_to_1_at_times": [
+            "transition_probabilities_to_1_at_times": [
                 1.0 * (1 / 7),
                 (6 / 7) * (1 / 5),
                 (6 / 7) * (3 / 5) * 0.0,
             ],
-            "trainsition_probabilities_to_2_at_times": [
+            "transition_probabilities_to_2_at_times": [
                 1.0 * 0.0,
                 (6 / 7) * (1 / 5),
                 (6 / 7) * (3 / 5) * 1.0,
@@ -278,12 +278,12 @@ def test_add_state_occupancy_probabilities_at_times_columns() -> None:
                 (6 / 7) * (3 / 5) * 0.0,
             ],
             "previous_overall_survival": [1.0, (6 / 7), (6 / 7) * (3 / 5)],
-            "trainsition_probabilities_to_1_at_times": [
+            "transition_probabilities_to_1_at_times": [
                 (1.0 * (1 / 7)),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 0.0),
             ],
-            "trainsition_probabilities_to_2_at_times": [
+            "transition_probabilities_to_2_at_times": [
                 (1.0 * 0.0),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 1.0),
@@ -310,12 +310,12 @@ def test_add_state_occupancy_probabilities_at_times_columns() -> None:
                 (6 / 7) * (3 / 5) * 0.0,
             ],
             "previous_overall_survival": [1.0, (6 / 7), (6 / 7) * (3 / 5)],
-            "trainsition_probabilities_to_1_at_times": [
+            "transition_probabilities_to_1_at_times": [
                 (1.0 * (1 / 7)),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 0.0),
             ],
-            "trainsition_probabilities_to_2_at_times": [
+            "transition_probabilities_to_2_at_times": [
                 (1.0 * 0.0),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 1.0),
@@ -360,12 +360,12 @@ def test_prepare_event_table() -> None:
                 (6 / 7) * (3 / 5) * 0.0,
             ],
             "previous_overall_survival": [1.0, (6 / 7), (6 / 7) * (3 / 5)],
-            "trainsition_probabilities_to_1_at_times": [
+            "transition_probabilities_to_1_at_times": [
                 (1.0 * (1 / 7)),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 0.0),
             ],
-            "trainsition_probabilities_to_2_at_times": [
+            "transition_probabilities_to_2_at_times": [
                 (1.0 * 0.0),
                 ((6 / 7) * (1 / 5)),
                 ((6 / 7) * (3 / 5) * 1.0),
@@ -432,3 +432,4 @@ def test_predict_aj_estimates() -> None:
     )
 
     assert_frame_equal(result, expected_output)
+

--- a/user_guide/02-how-it-works.qmd
+++ b/user_guide/02-how-it-works.qmd
@@ -70,7 +70,15 @@ The columns returned by `prepare_event_table()` expose each component of
 | `state_occupancy_probability_*_at_times` | Cumulative probability of occupying each absorbing state |
 
 The historical `trainsition_probabilities_to_*_at_times` spelling remains as
-a backward-compatible alias. New code should use the correctly spelled name.
+a backward-compatible alias. The corrected names were introduced in
+polarstate 0.1.8 and are the canonical names used by the implementation. New
+code should use the correctly spelled names and select event-table columns by
+name rather than position.
+
+There is currently no scheduled release that removes the historical aliases.
+If they are removed, polarstate will first announce the removal version and
+emit a deprecation warning during a documented compatibility window; removal
+will be released as a breaking schema change.
 
 ## From the event table to requested horizons
 
@@ -112,3 +120,4 @@ Compare the same estimates with other implementations in
 [Package Comparisons](04-package-comparisons.qmd), continue with
 [Recipes](05-recipes.qmd) for common data structures, or consult the
 [API Reference](../reference/index.html) for complete function details.
+


### PR DESCRIPTION
## Summary

- make the correctly spelled `transition_probabilities_to_*_at_times` columns canonical inside polarstate
- retain the historical `trainsition_probabilities_to_*_at_times` names as backward-compatible aliases
- update state-occupancy calculations and unit tests to use columns by their corrected names
- document that the corrected names were introduced in 0.1.8 and define the compatibility/removal policy

## Root cause

PR #69 exposed corrected aliases, but the implementation continued to compute from the misspelled columns and appended the corrected columns afterward. This reverses that relationship without breaking existing consumers.

## Downstream audit

`rtichoke`, `pseudostate`, and `weightedstate` were audited across source, tests, documentation, fixtures, and active branches. None consumes these event-table columns or relies on their positions, so no downstream code changes are required.

## Validation

- `pytest -q`
- 18 tests passed

Closes #70